### PR TITLE
Add automatic location detection and city search features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "urlencoding",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rust-embed = "8.5.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["time"] }
+urlencoding = "2.1"
 
 
 [dependencies.i18n-embed]

--- a/res/packaging.just
+++ b/res/packaging.just
@@ -48,17 +48,17 @@ uninstall:
 # Installs files locally
 [no-cd]
 install-local:
-    install -Dm0755  ~/.local/bin/{{name}}
-    install -Dm0644  ${XDG_DATA_HOME:-~/.local/share}/{{desktop-path}}
-    install -Dm0644  ${XDG_DATA_HOME:-~/.local/share}/{{metainfo-path}}
-    install -Dm0644  ${XDG_DATA_HOME:-~/.local/share}/{{icons-dst}}
+    install -Dm0755 {{bin-src}} ~/.local/bin/{{name}}
+    install -Dm0644 {{desktop-src}} ${XDG_DATA_HOME:-~/.local/share}/applications/{{desktop}}
+    install -Dm0644 {{metainfo-src}} ${XDG_DATA_HOME:-~/.local/share}/metainfo/{{metainfo}}
+    install -Dm0644 {{icons-src}} ${XDG_DATA_HOME:-~/.local/share}/icons/hicolor/scalable/apps/{{icons}}
 
 # Uninstalls locally installed files
 uninstall-local:
     rm ~/.local/bin/{{name}}
-    rm ${XDG_DATA_HOME:-~/.local/share}/{{desktop-path}}
-    rm ${XDG_DATA_HOME:-~/.local/share}/{{metainfo-path}}
-    rm ${XDG_DATA_HOME:-~/.local/share}/{{icons-dst}}
+    rm ${XDG_DATA_HOME:-~/.local/share}/applications/{{desktop}}
+    rm ${XDG_DATA_HOME:-~/.local/share}/metainfo/{{metainfo}}
+    rm ${XDG_DATA_HOME:-~/.local/share}/icons/hicolor/scalable/apps/{{icons}}
 
 # Compiles and packages deb with release profile
 build-deb:

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,8 +50,10 @@ impl TemperatureUnit {
 pub struct Config {
     pub latitude: f64,
     pub longitude: f64,
+    pub location_name: String,
     pub temperature_unit: TemperatureUnit,
     pub refresh_interval_minutes: u64,
+    pub use_auto_location: bool,
 }
 
 impl Default for Config {
@@ -59,8 +61,10 @@ impl Default for Config {
         Self {
             latitude: 40.7128,
             longitude: -74.0060,
+            location_name: "New York, NY, United States".to_string(),
             temperature_unit: TemperatureUnit::default(),
             refresh_interval_minutes: 15,
+            use_auto_location: false,
         }
     }
 }


### PR DESCRIPTION
- Implement IP-based auto-location using ip-api.com (no API key required)
- Add city search with Open-Meteo geocoding API returning multiple results
- Replace manual lat/lon input with user-friendly city search interface
- Store and display human-readable location names in config
- Fix install-local and uninstall-local recipes in packaging.just
- Add urlencoding dependency for proper city name encoding
- Update location name when auto-detection or city search is used