### PR TITLE
Add version display and Ko-fi support link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Click the applet to open the popup, which includes a settings section where you 
 - Toggle temperature unit (Fahrenheit/Celsius)
 - Enter custom latitude and longitude
 - Set refresh interval (in minutes)
+- View current version
+- Support development via Ko-fi
 
 Settings are automatically saved and will persist across sessions. The applet defaults to New York City coordinates (40.7128, -74.0060).
 

--- a/src/applet.rs
+++ b/src/applet.rs
@@ -13,6 +13,8 @@ use std::time::Duration;
 use crate::config::{Config, TemperatureUnit};
 use crate::weather::{WeatherData, fetch_weather, weathercode_to_description, weathercode_to_icon_name, format_hour, format_time, wind_direction_to_compass, detect_location, search_city, LocationResult};
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 /// This is the struct that represents your application.
 /// It is used to define the data that will be used by your application.
 pub struct Tempest {
@@ -90,6 +92,7 @@ pub enum Message {
     ToggleHourly,
     ToggleForecast,
     ToggleSettings,
+    OpenUrl(String),
 }
 
 /// Implement the `Application` trait for your application.
@@ -252,7 +255,7 @@ impl Application for Tempest {
     }
 
     fn view_window(&self, _id: Id) -> Element<'_, Self::Message> {
-        let mut column = widget::column().spacing(10).padding(10).max_width(450);
+        let mut column = widget::column().spacing(10).padding(10).max_width(500);
 
         // Add header with location name and refresh button
         let header = widget::row()
@@ -476,6 +479,24 @@ impl Application for Tempest {
                             .on_input(Message::UpdateRefreshInterval)
                     )
                 );
+
+                column = column.push(widget::divider::horizontal::default());
+
+                // Version and support info
+                column = column.push(
+                    settings::item(
+                        "Version",
+                        text(VERSION)
+                    )
+                );
+
+                column = column.push(
+                    settings::item(
+                        "Support Development",
+                        widget::button::text("Tip me on Ko-fi")
+                            .on_press(Message::OpenUrl("https://ko-fi.com/vintagetechie".to_string()))
+                    )
+                );
             }
         }
 
@@ -669,6 +690,11 @@ impl Application for Tempest {
             }
             Message::ToggleSettings => {
                 self.settings_expanded = !self.settings_expanded;
+            }
+            Message::OpenUrl(url) => {
+                if let Err(e) = open::that(&url) {
+                    eprintln!("Failed to open URL {}: {}", url, e);
+                }
             }
         }
         Task::none()


### PR DESCRIPTION
## Summary
- Added version display in settings section (reads from Cargo.toml)
- Added Ko-fi support button that opens browser to Ko-fi page
- Increased popup max width from 450 to 500 pixels for better readability
- Fixed Ko-fi button functionality using OpenUrl message handler

## Changes
- Added `VERSION` constant using `env!("CARGO_PKG_VERSION")`
- Added version display settings item
- Added Ko-fi button with `OpenUrl` message handler
- Implemented URL opening using the `open` crate
- Updated README with new configuration options

## Test plan
- [x] Build completes successfully
- [x] Version displays correctly in settings
- [x] Ko-fi button opens browser to correct URL
- [x] Popup width feels less cramped with new 500px max width