### PR TITLE
add air quality data from Open-Meteo API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-ext-applet-tempest"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "async-stream",
  "chrono",


### PR DESCRIPTION
Display AQI in panel alongside temperature. Auto-detects European locations and uses EU AQI scale; US AQI for everywhere else.

Popup shows collapsible air quality section with PM2.5, PM10, ozone, NO2, and CO readings. Weather and air quality fetched in parallel.

Also removes tooltip from panel button.