### PR TITLE
v1.1.0: UI polish and version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-ext-applet-tempest"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "async-stream",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmic-ext-applet-tempest"
-version = "1.0.2"
+version = "1.1.0"
 edition = "2021"
 authors = ["VintageTechie (John Crenshaw) <john@vintagetechie.com>"]
 license = "GPL-3.0-only"

--- a/res/com.vintagetechie.CosmicExtAppletTempest.metainfo.xml
+++ b/res/com.vintagetechie.CosmicExtAppletTempest.metainfo.xml
@@ -22,6 +22,8 @@
       <li>Current conditions including temperature, feels-like, and humidity</li>
       <li>Wind information with speed, direction compass, and gusts</li>
       <li>UV index, cloud cover, visibility, and atmospheric pressure</li>
+      <li>Air quality data with PM2.5, PM10, ozone, NO2, and CO readings</li>
+      <li>Auto-detects US or European AQI standard based on location</li>
       <li>Sunrise and sunset times with timezone support</li>
       <li>Collapsible hourly forecast for next 12 hours</li>
       <li>Collapsible 7-day forecast with high/low temperatures</li>
@@ -44,6 +46,22 @@
   </categories>
 
   <releases>
+    <release version="1.1.0" date="2025-11-25">
+      <description>
+        <p>Air quality and UI improvements</p>
+        <ul>
+          <li>Added air quality data from Open-Meteo API</li>
+          <li>AQI displayed in panel alongside temperature</li>
+          <li>Collapsible air quality section with PM2.5, PM10, ozone, NO2, CO</li>
+          <li>Auto-detects European locations and uses EU AQI scale</li>
+          <li>Weather and air quality fetched in parallel</li>
+          <li>Improved date formatting in 7-day forecast</li>
+          <li>Added weather icons to forecast rows</li>
+          <li>Replaced Unicode arrows with proper icons in collapsible headers</li>
+          <li>Removed emoji characters for cleaner appearance</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.0.1" date="2025-01-24">
       <description>
         <p>Metadata fix for COSMIC Store visibility</p>

--- a/src/applet.rs
+++ b/src/applet.rs
@@ -15,7 +15,7 @@ use crate::weather::{
     WeatherData, AirQualityData, AqiStandard,
     fetch_weather, fetch_air_quality,
     weathercode_to_description, weathercode_to_icon_name,
-    format_hour, format_time, wind_direction_to_compass,
+    format_hour, format_time, format_date, wind_direction_to_compass,
     detect_location, search_city, LocationResult,
     aqi_to_description, aqi_standard_label,
 };
@@ -362,17 +362,22 @@ impl Application for Tempest {
                 column = column.push(
                     widget::row()
                         .spacing(20)
-                        .push(text(format!("☀️ Sunrise: {}", format_time(&first_day.sunrise))).size(14))
-                        .push(text(format!("🌙 Sunset: {}", format_time(&first_day.sunset))).size(14))
+                        .push(text(format!("Sunrise: {}", format_time(&first_day.sunrise))).size(14))
+                        .push(text(format!("Sunset: {}", format_time(&first_day.sunset))).size(14))
                 );
             }
 
             column = column.push(widget::divider::horizontal::default());
 
             // Air Quality section with collapsible header
-            let air_quality_arrow = if self.air_quality_expanded { "▼" } else { "▶" };
+            let air_quality_icon = if self.air_quality_expanded { "go-down-symbolic" } else { "go-next-symbolic" };
             column = column.push(
-                widget::button::text(format!("{} Air Quality", air_quality_arrow))
+                widget::button::custom(
+                    widget::row()
+                        .spacing(8)
+                        .push(widget::icon::from_name(air_quality_icon).size(16).symbolic(true))
+                        .push(text("Air Quality"))
+                )
                     .on_press(Message::ToggleAirQuality)
                     .width(cosmic::iced::Length::Fill)
             );
@@ -414,9 +419,14 @@ impl Application for Tempest {
             column = column.push(widget::divider::horizontal::default());
 
             // Hourly forecast with collapsible header
-            let hourly_arrow = if self.hourly_expanded { "▼" } else { "▶" };
+            let hourly_icon = if self.hourly_expanded { "go-down-symbolic" } else { "go-next-symbolic" };
             column = column.push(
-                widget::button::text(format!("{} Next 12 Hours", hourly_arrow))
+                widget::button::custom(
+                    widget::row()
+                        .spacing(8)
+                        .push(widget::icon::from_name(hourly_icon).size(16).symbolic(true))
+                        .push(text("Next 12 Hours"))
+                )
                     .on_press(Message::ToggleHourly)
                     .width(cosmic::iced::Length::Fill)
             );
@@ -426,10 +436,10 @@ impl Application for Tempest {
                     column = column.push(
                         widget::row()
                             .spacing(10)
-                            .push(text(format_hour(&hour.time)).width(80))
+                            .push(text(format_hour(&hour.time)).width(70))
                             .push(widget::icon::from_name(weathercode_to_icon_name(hour.weathercode, false)).size(16).symbolic(true))
-                            .push(text(format!("{:.0}{}", hour.temperature, self.config.temperature_unit.symbol())).width(50))
-                            .push(text(format!("💧 {}%", hour.precipitation_probability)).width(60))
+                            .push(text(format!("{:.0}{}", hour.temperature, self.config.temperature_unit.symbol())).width(45))
+                            .push(text(format!("{}%", hour.precipitation_probability)).width(35))
                     );
                 }
             }
@@ -437,9 +447,14 @@ impl Application for Tempest {
             column = column.push(widget::divider::horizontal::default());
 
             // 7-day forecast with collapsible header
-            let forecast_arrow = if self.forecast_expanded { "▼" } else { "▶" };
+            let forecast_icon = if self.forecast_expanded { "go-down-symbolic" } else { "go-next-symbolic" };
             column = column.push(
-                widget::button::text(format!("{} 7-Day Forecast", forecast_arrow))
+                widget::button::custom(
+                    widget::row()
+                        .spacing(8)
+                        .push(widget::icon::from_name(forecast_icon).size(16).symbolic(true))
+                        .push(text("7-Day Forecast"))
+                )
                     .on_press(Message::ToggleForecast)
                     .width(cosmic::iced::Length::Fill)
             );
@@ -449,9 +464,10 @@ impl Application for Tempest {
                     column = column.push(
                         widget::row()
                             .spacing(10)
-                            .push(text(&day.date).width(100))
-                            .push(text(format!("{:.0}°", day.temp_max)).width(40))
-                            .push(text(format!("{:.0}°", day.temp_min)).width(40))
+                            .push(text(format_date(&day.date)).width(90))
+                            .push(widget::icon::from_name(weathercode_to_icon_name(day.weathercode, false)).size(16).symbolic(true))
+                            .push(text(format!("{:.0}°", day.temp_max)).width(35))
+                            .push(text(format!("{:.0}°", day.temp_min)).width(35))
                             .push(text(weathercode_to_description(day.weathercode)))
                     );
                 }
@@ -460,9 +476,14 @@ impl Application for Tempest {
             column = column.push(widget::divider::horizontal::default());
 
             // Settings section with collapsible header
-            let settings_arrow = if self.settings_expanded { "▼" } else { "▶" };
+            let settings_icon = if self.settings_expanded { "go-down-symbolic" } else { "go-next-symbolic" };
             column = column.push(
-                widget::button::text(format!("{} Settings", settings_arrow))
+                widget::button::custom(
+                    widget::row()
+                        .spacing(8)
+                        .push(widget::icon::from_name(settings_icon).size(16).symbolic(true))
+                        .push(text("Settings"))
+                )
                     .on_press(Message::ToggleSettings)
                     .width(cosmic::iced::Length::Fill)
             );

--- a/src/weather.rs
+++ b/src/weather.rs
@@ -388,6 +388,15 @@ pub fn format_time(time_str: &str) -> String {
     }
 }
 
+/// Formats date string to readable format (e.g., "2025-11-25" -> "Tue Nov 25")
+pub fn format_date(date_str: &str) -> String {
+    if let Ok(date) = chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
+        date.format("%a %b %d").to_string()
+    } else {
+        date_str.to_string()
+    }
+}
+
 /// Converts wind direction in degrees to compass direction
 pub fn wind_direction_to_compass(degrees: i32) -> &'static str {
     match degrees {


### PR DESCRIPTION
## Summary
- Bump version to 1.1.0
- Readable date format in 7-day forecast (Tue Nov 25 instead of 2025-11-25)
- Weather icons added to forecast rows
- Collapsible headers use proper symbolic icons instead of Unicode triangles
- Removed emoji characters from sunrise/sunset and hourly precipitation
- Tightened column widths for better alignment
- Metainfo updated with 1.1.0 release notes and air quality features

## Test plan
- [ ] Verify version shows 1.1.0 in Settings
- [ ] Check 7-day forecast dates display as "Tue Nov 25" format
- [ ] Confirm collapsible headers use arrow icons
- [ ] Verify no emoji characters in UI