### PR TITLE
v1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,63 @@ All notable changes to Tempest will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.1] - 2025-01-24
+## [1.4.0] - 2025-12-05
+
+### Added
+- Auto-select temperature and measurement units based on detected location
+- Weather alerts for US locations via NWS API
+
+### Changed
+- Sync README with current features
 
 ### Fixed
-- Changed metainfo component type from "addon" to "desktop-application" to appear in COSMIC Store's Applets tab
-- Added com.system76.CosmicApplet provides declaration for proper COSMIC applet identification
+- Packaging configuration in justfile
 
-## [1.0.0] - 2025-01-21
+## [1.3.0] - 2025-11-27
+
+### Added
+- Tabbed popup interface replacing collapsible sections
+- Night icon detection using actual sunrise/sunset times
+
+### Fixed
+- Resolved clippy warnings
+
+## [1.2.0] - 2025-11-26
+
+### Changed
+- Remember manual location settings between sessions
+- Sync measurement units with temperature unit selection
+
+## [1.1.0] - 2025-11-25
+
+### Added
+- Air quality data from Open-Meteo API
+- AQI displayed in panel alongside temperature
+- Collapsible air quality section with PM2.5, PM10, ozone, NO2, CO
+- Auto-detects European locations and uses EU AQI scale
+
+### Changed
+- UI polish and cleanup
+- Improved date formatting in 7-day forecast
+- Added weather icons to forecast rows
+- Replaced Unicode arrows with proper icons in collapsible headers
+
+## [1.0.2] - 2025-11-24
+
+### Added
+- Automated .deb package releases via GitHub Actions
+- install-dev target in justfile
+
+### Fixed
+- Remove %F argument causing Flatpak launch failure
+
+## [1.0.1] - 2025-11-24
+
+### Fixed
+- Changed metainfo component type to desktop-application for COSMIC Store visibility
+- Added com.system76.CosmicApplet provides declaration
+
+## [1.0.0] - 2025-11-21
 
 ### Added
 - Initial production release
@@ -37,5 +87,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Persistent configuration storage
 - Global weather coverage
 
+[1.4.0]: https://github.com/VintageTechie/cosmic-ext-applet-tempest/releases/tag/v1.4.0
+[1.3.0]: https://github.com/VintageTechie/cosmic-ext-applet-tempest/releases/tag/v1.3.0
+[1.2.0]: https://github.com/VintageTechie/cosmic-ext-applet-tempest/releases/tag/v1.2.0
+[1.1.0]: https://github.com/VintageTechie/cosmic-ext-applet-tempest/releases/tag/v1.1.0
+[1.0.2]: https://github.com/VintageTechie/cosmic-ext-applet-tempest/releases/tag/v1.0.2
 [1.0.1]: https://github.com/VintageTechie/cosmic-ext-applet-tempest/releases/tag/v1.0.1
 [1.0.0]: https://github.com/VintageTechie/cosmic-ext-applet-tempest/releases/tag/v1.0.0

--- a/res/com.vintagetechie.CosmicExtAppletTempest.metainfo.xml
+++ b/res/com.vintagetechie.CosmicExtAppletTempest.metainfo.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+that <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>com.vintagetechie.CosmicExtAppletTempest</id>
   <metadata_license>CC0-1.0</metadata_license>
@@ -10,23 +10,24 @@
     <p>
       Tempest is a weather applet for the COSMIC Desktop environment that provides
       real-time weather information with automatic location detection. It displays
-      current conditions, temperature, and forecasts directly in your panel.
+      current conditions, temperature, and AQI directly in your panel.
     </p>
     <p>Features:</p>
     <ul>
       <li>Real-time weather data from Open-Meteo API (no API key required)</li>
       <li>Automatic location detection via IP geolocation</li>
-      <li>Current temperature displayed in panel</li>
-      <li>Detailed popup with comprehensive weather information</li>
-      <li>Manual refresh button and last updated timestamp</li>
+      <li>Current temperature and AQI displayed in panel</li>
+      <li>Tabbed popup interface with weather, air quality, alerts, forecasts, and settings</li>
       <li>Current conditions including temperature, feels-like, and humidity</li>
       <li>Wind information with speed, direction compass, and gusts</li>
       <li>UV index, cloud cover, visibility, and atmospheric pressure</li>
+      <li>Sunrise and sunset times with timezone support</li>
       <li>Air quality data with PM2.5, PM10, ozone, NO2, and CO readings</li>
       <li>Auto-detects US or European AQI standard based on location</li>
-      <li>Sunrise and sunset times with timezone support</li>
-      <li>Collapsible hourly forecast for next 12 hours</li>
-      <li>Collapsible 7-day forecast with high/low temperatures</li>
+      <li>Weather alerts for US locations via NWS API</li>
+      <li>Hourly forecast for next 12 hours</li>
+      <li>7-day forecast with high/low temperatures</li>
+      <li>Auto-select temperature and measurement units based on location</li>
       <li>Configurable temperature units (Fahrenheit/Celsius)</li>
       <li>Custom location support (latitude/longitude)</li>
       <li>Adjustable refresh interval</li>
@@ -46,6 +47,35 @@
   </categories>
 
   <releases>
+    <release version="1.4.0" date="2025-12-05">
+      <description>
+        <p>Auto-units and weather alerts</p>
+        <ul>
+          <li>Auto-select temperature and measurement units based on detected location</li>
+          <li>Weather alerts for US locations via NWS API</li>
+          <li>Fixed packaging configuration in justfile</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.3.0" date="2025-11-27">
+      <description>
+        <p>Tabbed interface</p>
+        <ul>
+          <li>Tabbed popup interface replacing collapsible sections</li>
+          <li>Night icon detection using actual sunrise/sunset times</li>
+          <li>Resolved clippy warnings</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.2.0" date="2025-11-26">
+      <description>
+        <p>Location and unit improvements</p>
+        <ul>
+          <li>Remember manual location settings between sessions</li>
+          <li>Sync measurement units with temperature unit selection</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.1.0" date="2025-11-25">
       <description>
         <p>Air quality and UI improvements</p>
@@ -54,15 +84,22 @@
           <li>AQI displayed in panel alongside temperature</li>
           <li>Collapsible air quality section with PM2.5, PM10, ozone, NO2, CO</li>
           <li>Auto-detects European locations and uses EU AQI scale</li>
-          <li>Weather and air quality fetched in parallel</li>
           <li>Improved date formatting in 7-day forecast</li>
           <li>Added weather icons to forecast rows</li>
-          <li>Replaced Unicode arrows with proper icons in collapsible headers</li>
-          <li>Removed emoji characters for cleaner appearance</li>
         </ul>
       </description>
     </release>
-    <release version="1.0.1" date="2025-01-24">
+    <release version="1.0.2" date="2025-11-24">
+      <description>
+        <p>CI/CD and Flatpak fix</p>
+        <ul>
+          <li>Automated .deb package releases via GitHub Actions</li>
+          <li>Added install-dev target in justfile</li>
+          <li>Fixed %F argument causing Flatpak launch failure</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.0.1" date="2025-11-24">
       <description>
         <p>Metadata fix for COSMIC Store visibility</p>
         <ul>
@@ -71,7 +108,7 @@
         </ul>
       </description>
     </release>
-    <release version="1.0.0" date="2025-01-21">
+    <release version="1.0.0" date="2025-11-21">
       <description>
         <p>Initial production release</p>
         <ul>


### PR DESCRIPTION
## Summary

- Reconstruct CHANGELOG.md from git tags with accurate version history (1.0.0 through 1.4.0)
- Update metainfo.xml with missing release entries (1.0.2, 1.2.0, 1.3.0, 1.4.0)
- Refresh metainfo feature list to reflect current capabilities

## Changes in 1.4.0

- Auto-select temperature and measurement units based on detected location
- Weather alerts for US locations via NWS API
- Fixed packaging configuration in justfile

## Test plan

- [ ] Verify CHANGELOG.md formatting and links
- [ ] Verify metainfo.xml validates correctly
- [ ] After merge, tag v1.4.0 and create GitHub release