### PR TITLE
add EU weather alerts via MeteoAlarm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,6 +1059,7 @@ dependencies = [
  "libcosmic",
  "notify-rust",
  "open",
+ "quick-xml",
  "reqwest",
  "rust-embed",
  "serde",
@@ -4404,6 +4405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0"
 tokio = { version = "1", features = ["time"] }
 urlencoding = "2.1"
 notify-rust = "4"
+quick-xml = { version = "0.37", features = ["serialize"] }
 
 
 [dependencies.i18n-embed]

--- a/src/applet.rs
+++ b/src/applet.rs
@@ -699,7 +699,7 @@ impl Application for Tempest {
                                 widget::toggler(self.config.alerts_enabled)
                                     .on_toggle(|_| Message::ToggleAlertsEnabled),
                             )
-                            .push(text("US only").size(11)),
+                            .push(text("US & EU").size(11)),
                     ));
 
                     column = column.push(widget::divider::horizontal::default());

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,7 +113,7 @@ pub struct Config {
     pub last_updated: Option<i64>,
     /// Last selected tab, restored on popup open.
     pub default_tab: PopupTab,
-    /// Enable weather alerts (US only via NWS).
+    /// Enable weather alerts (US via NWS, EU via MeteoAlarm).
     #[serde(default = "default_alerts_enabled")]
     pub alerts_enabled: bool,
     /// Automatically select units based on detected location.


### PR DESCRIPTION
Integrates MeteoAlarm Atom feeds for 38 European countries. Resolves user's specific region using Nominatim reverse geocoding to match against EMMA_ID geocodes, so you only see alerts that actually affect your area instead of the whole country.

Adds quick-xml for Atom/CAP parsing, country-to-MeteoAlam mapping with proper ISO codes, EMMA_ID resolution via location name matching. UI label now shows "US & EU".

## Summary

Brief description of changes.

## Related Issue

Fixes #24 

## Checklist

- [ ] Code compiles without warnings (`just check`)
- [ ] Tested on COSMIC desktop
- [ ] Updated CHANGELOG.md (if user-facing change)