### PR TITLE
add alert description to weather alerts display

### DIFF
--- a/src/applet.rs
+++ b/src/applet.rs
@@ -536,6 +536,19 @@ impl Application for Tempest {
                                                 .push(text(&alert.event).size(14)),
                                         )
                                         .push(text(&alert.headline).size(12))
+                                        .push_maybe(if alert.description.is_empty() {
+                                            None
+                                        } else {
+                                            Some(
+                                                widget::container(
+                                                    widget::scrollable(
+                                                        text(&alert.description).size(11),
+                                                    )
+                                                    .height(cosmic::iced::Length::Fixed(100.0)),
+                                                )
+                                                .padding([4, 0, 4, 0]),
+                                            )
+                                        })
                                         .push(
                                             text(format!(
                                                 "Expires: {}",


### PR DESCRIPTION
shows the full alert text in a scrollable container below the headline, giving users the actual details about what the alert means instead of just the event name.

## Summary

Brief description of changes.

## Related Issue

Fixes #

## Checklist

- [ ] Code compiles without warnings (`just check`)
- [ ] Tested on COSMIC desktop
- [ ] Updated CHANGELOG.md (if user-facing change)