### PR TITLE
refactor region detection and cache timestamp display

### DIFF
--- a/res/com.vintagetechie.CosmicExtAppletTempest.metainfo.xml
+++ b/res/com.vintagetechie.CosmicExtAppletTempest.metainfo.xml
@@ -37,9 +37,7 @@
   <url type="homepage">https://github.com/VintageTechie/cosmic-ext-applet-tempest</url>
   <url type="bugtracker">https://github.com/VintageTechie/cosmic-ext-applet-tempest/issues</url>
   <url type="donation">https://ko-fi.com/vintagetechie</url>
-  <developer id="com.vintagetechie">
-    <name>VintageTechie (John Crenshaw)</name>
-  </developer>
+  <developer_name>VintageTechie (J. Crenshaw)</developer_name>
   <update_contact>john@vintagetechie.com</update_contact>
   <launchable type="desktop-id">com.vintagetechie.CosmicExtAppletTempest.desktop</launchable>
 


### PR DESCRIPTION
## Summary

Unified `Region` enum replaces scattered `is_us_coordinates()` / `is_european_location()` checks
Single `detect_region()` function handles dispatch for alerts and AQI standard selection
Canada bounding box added (alerts stubbed for now)
Cached timestamp string stops the view from reformatting DateTime on every keystroke