### PR TITLE
add weather alerts for canada via eccc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-ext-applet-tempest"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "async-stream",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmic-ext-applet-tempest"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2021"
 authors = ["VintageTechie (John Crenshaw) <john@vintagetechie.com>"]
 license = "GPL-3.0-only"

--- a/res/com.vintagetechie.CosmicExtAppletTempest.metainfo.xml
+++ b/res/com.vintagetechie.CosmicExtAppletTempest.metainfo.xml
@@ -24,7 +24,7 @@
       <li>Sunrise and sunset times with timezone support</li>
       <li>Air quality data with PM2.5, PM10, ozone, NO2, and CO readings</li>
       <li>Auto-detects US or European AQI standard based on location</li>
-      <li>Weather alerts for US (NWS) and European (MeteoAlarm) locations</li>
+      <li>Weather alerts for US (NWS), Canadian (ECCC), and European (MeteoAlarm) locations</li>
       <li>Hourly forecast for next 12 hours</li>
       <li>7-day forecast with high/low temperatures</li>
       <li>Auto-select temperature and measurement units based on location</li>
@@ -47,6 +47,16 @@
   </categories>
 
   <releases>
+    <release version="1.5.0" date="2025-12-10">
+      <description>
+        <p>Canadian weather alerts</p>
+        <ul>
+          <li>Weather alerts for Canadian locations via ECCC (Environment and Climate Change Canada)</li>
+          <li>Point-in-polygon filtering for precise alert matching</li>
+          <li>Improved US/Canada border region detection</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.4.1" date="2025-12-08">
       <description>
         <p>Alert details and updated screenshots</p>


### PR DESCRIPTION
## Summary
- Weather alerts for Canadian locations via ECCC (Environment and Climate Change Canada)
- Point-in-polygon filtering for precise alert matching to user's location
- Fixed US/Canada region detection in the Great Lakes area
