### PR TITLE
add toggle to show/hide AQI in panel

### DIFF
--- a/src/applet.rs
+++ b/src/applet.rs
@@ -100,6 +100,7 @@ pub enum Message {
     Tick,
     ToggleTemperatureUnit,
     ToggleAlertsEnabled,
+    ToggleShowAqiInPanel,
     ToggleAutoUnits,
     UpdateCityInput(String),
     SearchCity,
@@ -246,9 +247,11 @@ impl Application for Tempest {
                 row = row.push(alert_icon);
             }
             row = row.push(icon).push(temperature_text);
-            if let Some((aqi, _)) = self.current_aqi {
-                row = row.push(text("|").size(12));
-                row = row.push(text(format!("AQI {}", aqi)));
+            if self.config.show_aqi_in_panel {
+                if let Some((aqi, _)) = self.current_aqi {
+                    row = row.push(text("|").size(12));
+                    row = row.push(text(format!("AQI {}", aqi)));
+                }
             }
             Element::from(row)
         } else {
@@ -259,8 +262,10 @@ impl Application for Tempest {
                 col = col.push(alert_icon);
             }
             col = col.push(icon).push(temperature_text);
-            if let Some((aqi, _)) = self.current_aqi {
-                col = col.push(text(format!("AQI {}", aqi)).size(12));
+            if self.config.show_aqi_in_panel {
+                if let Some((aqi, _)) = self.current_aqi {
+                    col = col.push(text(format!("AQI {}", aqi)).size(12));
+                }
             }
             Element::from(col)
         };
@@ -838,6 +843,12 @@ impl Application for Tempest {
                             .push(text("US & EU").size(11)),
                     ));
 
+                    column = column.push(settings::item(
+                        "Show AQI in Panel",
+                        widget::toggler(self.config.show_aqi_in_panel)
+                            .on_toggle(|_| Message::ToggleShowAqiInPanel),
+                    ));
+
                     column = column.push(widget::divider::horizontal::default());
 
                     // About section
@@ -1027,6 +1038,10 @@ impl Application for Tempest {
                 }
                 self.save_config();
                 return Task::perform(async { Message::RefreshWeather }, Action::App);
+            }
+            Message::ToggleShowAqiInPanel => {
+                self.config.show_aqi_in_panel = !self.config.show_aqi_in_panel;
+                self.save_config();
             }
             Message::ToggleAutoUnits => {
                 self.config.auto_units = !self.config.auto_units;

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,6 +120,9 @@ pub struct Config {
     /// Automatically select units based on detected location.
     #[serde(default = "default_auto_units")]
     pub auto_units: bool,
+    /// Show AQI in the panel display.
+    #[serde(default = "default_show_aqi_in_panel")]
+    pub show_aqi_in_panel: bool,
 }
 
 fn default_alerts_enabled() -> bool {
@@ -127,6 +130,10 @@ fn default_alerts_enabled() -> bool {
 }
 
 fn default_auto_units() -> bool {
+    true
+}
+
+fn default_show_aqi_in_panel() -> bool {
     true
 }
 
@@ -147,6 +154,7 @@ impl Default for Config {
             default_tab: PopupTab::default(),
             alerts_enabled: true,
             auto_units: true,
+            show_aqi_in_panel: true,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `show_aqi_in_panel` config option (defaults to true)
- New toggle in Settings tab under "Show AQI in Panel"
- Hides AQI from panel display when disabled, Air Quality tab still works

## Test plan
- [ ] Toggle off, confirm AQI disappears from panel
- [ ] Toggle on, confirm AQI reappears
- [ ] Verify Air Quality tab still shows data regardless of toggle
- [ ] Test both horizontal and vertical panel layouts